### PR TITLE
Add constructors and properties to Invoice class

### DIFF
--- a/eshop/Components/Pages/invoice components/Invoice.cs
+++ b/eshop/Components/Pages/invoice components/Invoice.cs
@@ -5,6 +5,16 @@ namespace eshop.Components.Pages.invoice_components
 {
     public class Invoice
     {
+        public Invoice() { }
+        public Invoice(int id)
+        {
+            int InvoiceId = id;
+        }
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Email { get; set; }
+        public string Phone { get; set; }
         
     }
 }


### PR DESCRIPTION
Updated the `Invoice` class in the `eshop.Components.Pages.invoice_components` namespace to include a parameterless constructor and a constructor that accepts an `int` parameter for the invoice ID. Added properties for `Id`, `Name`, `Description`, `Email`, and `Phone` to store invoice details.